### PR TITLE
Add filter to resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [IMPROVEMENT] Simplified marshalling.
 - [IMPROVEMENT] Add CSEBase to Session Resource. 
 - [IMPROVEMENT] Add Originator to Resources.
+- [IMPROVEMENT] Add optional Filter Parameter for finding SubResources.
 
 
 ## Version 0.7 (2018-05-13)

--- a/onem2mlib/internal.py
+++ b/onem2mlib/internal.py
@@ -297,7 +297,7 @@ def _findSubResource(resource, type, filter=None, originator=None):
 		#	number of path elements, and only add those from the response to the result
 		#	which have count+1 path elements.
 
-		sid = resource._structuredResourceID(withoutPrefix=True)
+		sid = resource._structuredResourceID()
 		count = sid.count('/') + 1
 
 		for ri in ris:

--- a/onem2mlib/internal.py
+++ b/onem2mlib/internal.py
@@ -270,13 +270,25 @@ def typeToString(ty):
 #
 
 # Find a sub-resource
-def _findSubResource(resource, type, originator=None):
+def _findSubResource(resource, type, filter=None, originator=None):
 	import onem2mlib.utilities
 
 	if not resource or not resource.session or not resource.resourceID: 
 		return None
 	result = []
-	ris = onem2mlib.mcarequests.discoverInCSE(resource, filter=[onem2mlib.utilities.newTypeFilterCriteria(int(type))], structuredResult=True, originator=originator)
+ 
+	combined_filter = [onem2mlib.utilities.newTypeFilterCriteria(int(type))]
+	
+	if filter:
+		if isinstance(filter, list):
+			combined_filter.extend(filter)
+		else:
+			# Handle case where only a single tuple was passed instead of a list
+			combined_filter.append(filter)
+
+ 
+ 
+	ris = onem2mlib.mcarequests.discoverInCSE(resource, filter=combined_filter, structuredResult=True, originator=originator)
 	if ris:
 		#	The following is a hack to restrict the search result to the direct child
 		#	level. Yes, the oneM2M "level" attribute could be used for that, but it
@@ -285,7 +297,7 @@ def _findSubResource(resource, type, originator=None):
 		#	number of path elements, and only add those from the response to the result
 		#	which have count+1 path elements.
 
-		sid = resource._structuredResourceID()
+		sid = resource._structuredResourceID(withoutPrefix=True)
 		count = sid.count('/') + 1
 
 		for ri in ris:

--- a/onem2mlib/mcarequests.py
+++ b/onem2mlib/mcarequests.py
@@ -39,11 +39,11 @@ def retrieveFromCSE(resource, originator=None):
     # Otherwise, use Structured ID.
     ids_to_try = []
     if resource.resourceID:
-        ids_to_try.append(("unstructured", resource._unstructuredResourceID()))
+        ids_to_try.append(("unstructured", resource._unstructuredResourceID(withRIScope=True)))
     
     # Always add structured as a candidate if name is known
     if resource.resourceName:
-        ids_to_try.append(("structured", resource._structuredResourceID()))
+        ids_to_try.append(("structured", resource._structuredResourceID(withRIScope=True)))
 
     for id_type, target_id in ids_to_try:
         try:
@@ -90,9 +90,9 @@ def createInCSE(resource, type, originator=None):
     # Collect potential parent IDs to try
     parent_targets = []
     if resource.parent.resourceID:
-        parent_targets.append(('unstructured', resource.parent._unstructuredResourceID()))
+        parent_targets.append(('unstructured', resource.parent._unstructuredResourceID(withRIScope=True)))
     if resource.parent.resourceName:
-        parent_targets.append(('structured', resource.parent._structuredResourceID()))
+        parent_targets.append(('structured', resource.parent._structuredResourceID(withRIScope=True)))
 
     for id_type, target_id in parent_targets:
         try:
@@ -131,9 +131,9 @@ def deleteFromCSE(resource, originator=None):
 
     targets = []
     if resource.resourceID:
-        targets.append(('unstructured', resource._unstructuredResourceID()))
+        targets.append(('unstructured', resource._unstructuredResourceID(withRIScope=True)))
     if resource.resourceName:
-        targets.append(('structured', resource._structuredResourceID()))
+        targets.append(('structured', resource._structuredResourceID(withRIScope=True)))
 
     for id_type, target_id in targets:
         try:
@@ -171,9 +171,9 @@ def updateInCSE(resource, type, originator=None):
     
     targets = []
     if resource.resourceID:
-        targets.append(('unstructured', resource._unstructuredResourceID()))
+        targets.append(('unstructured', resource._unstructuredResourceID(withRIScope=True)))
     if resource.resourceName:
-        targets.append(('structured', resource._structuredResourceID()))
+        targets.append(('structured', resource._structuredResourceID(withRIScope=True)))
 
     for id_type, target_id in targets:
         try:
@@ -224,9 +224,9 @@ def discoverInCSE(resource, filter=None, filterOperation=None, structuredResult=
     # 2. Define the target IDs to try
     targets = []
     if resource.resourceID:
-        targets.append(('unstructured', resource._unstructuredResourceID()))
+        targets.append(('unstructured', resource._unstructuredResourceID(withRIScope=True)))
     if resource.resourceName:
-        targets.append(('structured', resource._structuredResourceID()))
+        targets.append(('structured', resource._structuredResourceID(withRIScope=True)))
 
     # 3. Iterate through targets with fallback logic
     for id_type, base_path in targets:

--- a/onem2mlib/notifications.py
+++ b/onem2mlib/notifications.py
@@ -241,14 +241,14 @@ def hasSubscription(resource):
 def _addSubscription(resource, sub, callback):
 	_subscriptions[resource.resourceID] = (sub, resource, callback)
 	_subscriptionIDToParentResourceID[sub.resourceID] = resource.resourceID
-	_subscriptionIDToParentResourceID[sub._structuredResourceID()] = resource.resourceID
+	_subscriptionIDToParentResourceID[sub._structuredResourceID(withRIScope=True)] = resource.resourceID
 
 
 # Remove a subscription from the internal data structures
 def _removeSubscriptionByID(resourceID):
 	(sub, _, _) = _subscriptions.pop(resourceID)
 	_subscriptionIDToParentResourceID.pop(sub.resourceID)
-	_subscriptionIDToParentResourceID.pop(sub._structuredResourceID())
+	_subscriptionIDToParentResourceID.pop(sub._structuredResourceID(withRIScope=True))
 	return sub.deleteFromCSE()
 
 

--- a/onem2mlib/resources/AE.py
+++ b/onem2mlib/resources/AE.py
@@ -90,11 +90,11 @@ class AE(ResourceBase):
 		return result
 
 
-	def containers(self):
+	def containers(self, filter=None):
 		"""
 		Return a list of all &lt;container> resources of this &lt;AE>, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_Container)
+		return INT._findSubResource(self, CON.Type_Container, filter=filter)
 
 
 	def addContainer(self, resourceName=None, maxNrOfInstances=None, maxByteSize=None, maxInstanceAge=None, labels=[], originator=None):
@@ -106,11 +106,11 @@ class AE(ResourceBase):
 		return Container(self, resourceName, maxNrOfInstances=maxNrOfInstances, maxByteSize=maxByteSize, maxInstanceAge=maxInstanceAge, labels=labels, originator=originator)
 
 
-	# def flexContainers(self):
+	# def flexContainers(self, filter=None):
 	# 	"""
 	# 	Return a list of all &lt;flexContainer> resources of this &lt;AE>, or an empty list.
 	# 	"""
-	# 	return _findSubResource(self, CON.Type_FlexContainer)
+	# 	return _findSubResource(self, CON.Type_FlexContainer, filter=filter)
 
 
 	# def findFlexContainer(self, resourceName):
@@ -120,11 +120,11 @@ class AE(ResourceBase):
 	# 	return _getResourceFromCSEByResourceName(CON.Type_FlexContainer, resourceName, self)
 
 
-	def groups(self):
+	def groups(self, filter=None):
 		"""
 		Return a list of all &lt;group> resources of this &lt;AE>, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_Group)
+		return INT._findSubResource(self, CON.Type_Group, filter=filter)
 
 
 	def addGroup(self, resourceName=None, resources=[], maxNrOfMembers=CON.Grp_def_maxNrOfMembers, consistencyStrategy=CON.Grp_ABANDON_MEMBER, groupName=None, labels = [], originator=None,  instantly=True):

--- a/onem2mlib/resources/CSEBase.py
+++ b/onem2mlib/resources/CSEBase.py
@@ -66,18 +66,18 @@ class CSEBase(ResourceBase):
 		return result
 
 
-	def accessControlPolicies(self):
+	def accessControlPolicies(self, filter=None):
 		"""
 		Return a list of &lt;accessControlPolicy> resources from this CSE, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_ACP)
+		return INT._findSubResource(self, CON.Type_ACP, filter=filter)
 
 
-	def aes(self):
+	def aes(self, filter=None):
 		"""
 		Return a list of &lt;AE> resources from this CSE, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_AE)
+		return INT._findSubResource(self, CON.Type_AE, filter=filter)
 
 
 	def addAE(self, resourceName=None, appID=None, AEID=None, resourceID=None, requestReachability=True, labels=[], originator=None):
@@ -89,11 +89,11 @@ class CSEBase(ResourceBase):
 		return AE(self, resourceName, appID, AEID, resourceID, requestReachability, labels=labels, originator=originator)
 
 
-	def containers(self):
+	def containers(self, filter=None):
 		"""
 		Return a list of all &lt;container> resources of this &lt;CSEBase>, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_Container)
+		return INT._findSubResource(self, CON.Type_Container, filter=filter)
 
 
 	def addContainer(self, resourceName=None, maxNrOfInstances=None, maxByteSize=None, maxInstanceAge=None, labels=[], originator=None):
@@ -105,11 +105,11 @@ class CSEBase(ResourceBase):
 		return Container(self, resourceName, maxNrOfInstances=maxNrOfInstances, maxByteSize=maxByteSize, maxInstanceAge=maxInstanceAge, labels=labels, originator=originator)
 
 
-	def groups(self):
+	def groups(self, filter=None):
 		"""
 		Return a list of &lt;group> resources from this CSE, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_Group)
+		return INT._findSubResource(self, CON.Type_Group, filter=filter)
 
 
 	def addGroup(self, resourceName=None, resources=[], maxNrOfMembers=CON.Grp_def_maxNrOfMembers, consistencyStrategy=CON.Grp_ABANDON_MEMBER, groupName=None, labels = [], originator=None, instantly=True):
@@ -121,11 +121,11 @@ class CSEBase(ResourceBase):
 		return Group(self, resourceName=resourceName, resources=resources, maxNrOfMembers=maxNrOfMembers, consistencyStrategy=consistencyStrategy, groupName=groupName, labels=labels, originator=originator)
 
 
-	def remoteCSEs(self):
+	def remoteCSEs(self, filter=None):
 		"""
 		Return a list of &lt;remoteCSE> resources from this CSE, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_RemoteCSE)
+		return INT._findSubResource(self, CON.Type_RemoteCSE, filter=filter)
 
 
 	def _copy(self, resource):

--- a/onem2mlib/resources/Container.py
+++ b/onem2mlib/resources/Container.py
@@ -92,11 +92,11 @@ class Container(ResourceBase):
 		return result
 
 
-	def containers(self):
+	def containers(self, filter=None):
 		"""
 		Return all &lt;container> sub-resources from this container, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_Container)
+		return INT._findSubResource(self, CON.Type_Container, filter=filter)
 
 
 	def addContainer(self, resourceName=None, maxNrOfInstances=None, maxByteSize=None, maxInstanceAge=None, labels=[], originator=None):
@@ -108,18 +108,18 @@ class Container(ResourceBase):
 		return Container(self, resourceName, maxNrOfInstances=maxNrOfInstances, maxByteSize=maxByteSize, maxInstanceAge=maxInstanceAge, labels=labels, originator=originator)
 
 
-	def contentInstances(self):
+	def contentInstances(self, filter=None):
 		"""
 		Return all &lt;contentInstance> sub-resources from this container, or an empty list.
 		"""
-		return INT._findSubResource(self, CON.Type_ContentInstance)
+		return INT._findSubResource(self, CON.Type_ContentInstance, filter=filter)
 
 
-	def contents(self):
+	def contents(self, filter=None):
 		"""
 		Return all content from all &lt;contentInstance>'s in list, or an empty list.
 		"""
-		return [cin.content for cin in self.contentInstances()]
+		return [cin.content for cin in self.contentInstances(filter=filter)]
 
 
 	def addContent(self, value, labels=[], originator=None):

--- a/onem2mlib/resources/ResourceBase.py
+++ b/onem2mlib/resources/ResourceBase.py
@@ -318,7 +318,7 @@ class ResourceBase:
 		return NOT.removeSubscription(self)
 
 
-	def subscriptions(self):
+	def subscriptions(self, filter=None):
 		"""
 		Return a list of &lt;subscription> resources of a rersource, or an empty list.
 
@@ -328,7 +328,7 @@ class ResourceBase:
 		if self.type not in NOT._allowedSubscriptionResources:
 			logger.error('Subscription not supported for this resource type: ' + INT.nameAndType(self))
 			raise EXC.NotSupportedError('Subscription not supported for this resource type')
-		return INT._findSubResource(self, CON.Type_Subscription)
+		return INT._findSubResource(self, CON.Type_Subscription, filter=filter)
 
 
 	def findAccessControlPolicy(self, resourceName):
@@ -425,7 +425,12 @@ class ResourceBase:
 		# returns CSE relative path (empty string)
 		return ''
 
-	def _unstructuredResourceID(self):
+	def _unstructuredResourceID(self, withoutPrefix:bool = False) -> str:
+		ri = self.resourceID.lstrip('/')
+		if withoutPrefix:
+			return ri
+
+		# Find the root only if prefix is needed
 		root = self
 		while hasattr(root, 'parent') and root.parent is not None:
 			root = root.parent
@@ -434,33 +439,30 @@ class ResourceBase:
 		if root.type == CON.Type_RemoteCSE:
 			base = root._prefixResourceIDAbsolute()
 		elif root.type == CON.Type_CSEBase:
-			base = root._prefixResourceIDSPRelative()
-			if base is None:
-				base = root._prefixResourceIDCSERelative()
+			base = root._prefixResourceIDSPRelative() or root._prefixResourceIDCSERelative()
 		else:
 			base = ''
 			
 		prefix = (base or '').rstrip('/')
-		ri = self.resourceID.lstrip('/')
 		return f"{prefix}/{ri}"
 
-	# Recursively construct a structured resourceName
-	def _structuredResourceID(self):
-		logger.debug('ResourceID: ' + str(self.resourceID))
-		
+	def _structuredResourceID(self, withoutPrefix:bool = False) -> str:
 		# Handle RemoteCSE case
 		if self.type == CON.Type_RemoteCSE:
+			if withoutPrefix:
+				return self.resourceName
 			prefix = self._prefixResourceIDAbsolute()
-			return (prefix if prefix is not None else '') + '/' + self.resourceName
+			return f"{(prefix or '')}/{self.resourceName}"
 			
 		# Handle CSEBase case
 		if self.type == CON.Type_CSEBase:
-			prefix = self._prefixResourceIDSPRelative()
-			if prefix is None:
-				prefix = self._prefixResourceIDCSERelative()
-			return prefix + '/' + self.resourceName
+			if withoutPrefix:
+				return self.resourceName
+			prefix = self._prefixResourceIDSPRelative() or self._prefixResourceIDCSERelative()
+			return f"{(prefix or '')}/{self.resourceName}"
 			
-		return self.parent._structuredResourceID() + '/' + self.resourceName
+		# Recursive Case: Propagate the 'withoutPrefix' flag
+		return f"{self.parent._structuredResourceID(withoutPrefix)}/{self.resourceName}"
 
 
 	def _parseResponse(self, response):

--- a/onem2mlib/resources/ResourceBase.py
+++ b/onem2mlib/resources/ResourceBase.py
@@ -425,12 +425,13 @@ class ResourceBase:
 		# returns CSE relative path (empty string)
 		return ''
 
-	def _unstructuredResourceID(self, withoutPrefix:bool = False) -> str:
+	def _unstructuredResourceID(self, withRIScope: bool = False) -> str:
 		ri = self.resourceID.lstrip('/')
-		if withoutPrefix:
+		
+		if not withRIScope:
 			return ri
 
-		# Find the root only if prefix is needed
+		# Find the root 
 		root = self
 		while hasattr(root, 'parent') and root.parent is not None:
 			root = root.parent
@@ -446,23 +447,22 @@ class ResourceBase:
 		prefix = (base or '').rstrip('/')
 		return f"{prefix}/{ri}"
 
-	def _structuredResourceID(self, withoutPrefix:bool = False) -> str:
+	def _structuredResourceID(self, withRIScope: bool = False) -> str:
 		# Handle RemoteCSE case
 		if self.type == CON.Type_RemoteCSE:
-			if withoutPrefix:
+			if not withRIScope:
 				return self.resourceName
 			prefix = self._prefixResourceIDAbsolute()
 			return f"{(prefix or '')}/{self.resourceName}"
 			
 		# Handle CSEBase case
 		if self.type == CON.Type_CSEBase:
-			if withoutPrefix:
+			if not withRIScope:
 				return self.resourceName
 			prefix = self._prefixResourceIDSPRelative() or self._prefixResourceIDCSERelative()
 			return f"{(prefix or '')}/{self.resourceName}"
-			
-		# Recursive Case: Propagate the 'withoutPrefix' flag
-		return f"{self.parent._structuredResourceID(withoutPrefix)}/{self.resourceName}"
+				
+		return f"{self.parent._structuredResourceID(withRIScope)}/{self.resourceName}"
 
 
 	def _parseResponse(self, response):


### PR DESCRIPTION
I added an option to refine the filter for finding subresources.

I needed to fix the _findSubResourceMethod:
while onem2mlib.mcarequests.discoverinCSE() returns structuredResourceIDs, our structuredResourceID() method also always returned the scope Identifier. 
In order to make the _findSubResource() method work correctly, I needed to add an optional withRIScope parameter to structuredResourceID(). 